### PR TITLE
Merge master into trees branch. (#165)

### DIFF
--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -6,7 +6,6 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     sudo apt update
     sudo apt install gfortran libopenmpi-dev openmpi-bin libnetcdf-dev libnetcdff-dev graphviz
 elif [[ "$OSTYPE" == "darwin"* ]]; then
-    brew install netcdf open-mpi graphviz
-    brew unlink gcc
-    brew link gcc@9
+    brew install netcdf netcdf-fortran open-mpi graphviz
+    brew link gcc
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       # See https://github.com/conda-incubator/setup-miniconda#IMPORTANT.
       shell: bash -l {0}
       run: |
-        if [ ${{ matrix.os }} = 'macos-latest' ]; then export FC=gfortran-9; fi
+        if [ ${{ matrix.os }} = 'macos-latest' ]; then export FC=gfortran-12; fi
         python3 -u tests/run_tests.py master $GITHUB_SHA ${{ matrix.build-type}}
 
     - name: Build docs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,8 @@ endif()
 find_package(MPI REQUIRED)
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
-    set(CMAKE_Fortran_FLAGS "-g -fbacktrace -fdefault-real-8 -ffree-line-length-none -ffpe-trap=invalid,zero,overflow")
-    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan -fcheck=all -Wextra -Wconversion -pedantic")
+    set(CMAKE_Fortran_FLAGS "-g -fbacktrace -fdefault-real-8 -ffree-line-length-none -ffpe-trap=invalid,zero,overflow -fallow-argument-mismatch")
+    set(CMAKE_Fortran_FLAGS_DEBUG "-O0 -finit-real=nan -fcheck=all -Wall -Wextra -Wuninitialized -Warray-bounds -Wconversion")
     set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
     # FIXME: `-heap-arrays 10` required as using Intel Fortran


### PR DESCRIPTION
* Allow MPI_BCAST to be used for multiple data types.

Necessary when gfortran version > 9. In future should probably be handled using interfaces.

* Use latest gfortran version in tests and fix debug compilation. (#150)